### PR TITLE
Text with the clock is now always in one line

### DIFF
--- a/app/src/main/java/com/cooper/wheellog/views/WheelView.java
+++ b/app/src/main/java/com/cooper/wheellog/views/WheelView.java
@@ -612,7 +612,7 @@ public class WheelView extends View {
         boxTextHeight = boundaryOfText.height();
 
         Paint paint = new Paint(textPaint);
-        paint.setColor(getContext().getResources().getColor(R.color.wheelview_text));
+        paint.setColor(getResources().getColor(R.color.wheelview_text));
 
         try {
             int i = 0;
@@ -777,7 +777,7 @@ public class WheelView extends View {
         canvas.drawTextOnPath(mWheelModel, modelTextPath, 0, 0, modelTextPaint);
 
         // Draw text blocks bitmap
-        canvas.drawBitmap(mTextBoxesBitmap, 0, 0, null);
+        canvas.drawBitmap(mTextBoxesBitmap, 0, 0, textPaint);
 
         refreshDisplay = currentSpeed != targetSpeed ||
                 currentCurrent != targetCurrent ||

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -24,14 +24,15 @@
 
             <android.widget.TextClock
                 android:id="@+id/textClock"
-                android:layout_height="wrap_content"
                 android:layout_width="match_parent"
-                android:format24Hour="HH:mm:ss"
+                android:layout_height="wrap_content"
                 android:format12Hour="HH:mm:ss"
-                android:textSize="30sp"
-                android:textStyle="bold"
+                android:format24Hour="HH:mm:ss"
+                android:gravity="start"
+                android:maxLines="1"
                 android:textColor="@color/wheelview_text"
-                android:gravity="start"/>
+                android:textSize="29sp"
+                android:textStyle="bold" />
         </androidx.appcompat.widget.Toolbar>
 
         <androidx.viewpager.widget.ViewPager

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -135,8 +135,6 @@
 	<string name="max_speed_dial_description">Максималната скорост показвана на външния ринг</string>
 	<string name="use_mph_title">Скорост и дистанция в мили</string>
 	<string name="use_mph_description">Показвай скоростта и дистанцията в мили вместо в километри</string>
-	<string name="use_eng_title">English</string>
-	<string name="use_eng_description">Use English language instead of Android system language</string>
 	<string name="enable_alarms_title">Включи алармите</string>
 	<string name="enable_alarms_description">Разреши нателефона да вибрира като предупреждение</string>
 	<string name="disable_phone_vibrate_title">Изключи вибрацията на телефона</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -135,8 +135,6 @@
 	<string name="max_speed_dial_description">Maximální rychlost zobrazená ciferníku</string>
 	<string name="use_mph_title">Rychlost a vzdálenost v mílích</string>
 	<string name="use_mph_description">Zobrazit míle místo kilometrů.</string>
-	<string name="use_eng_title">English</string>
-	<string name="use_eng_description">Use English language instead of Android system language</string>
 	<string name="enable_alarms_title">Zapnout upozornění</string>
 	<string name="enable_alarms_description">Zapnout vibrace zprávy jako upozornění.</string>
 	<string name="disable_phone_vibrate_title">Vypnout vybrace telefonu</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -135,8 +135,6 @@
 	<string name="max_speed_dial_description">Max. angezeigte Geschwindigkeit (Tachometer)</string>
 	<string name="use_mph_title">Geschwindigkeit und Entfernung in Meilen</string>
 	<string name="use_mph_description">Zeige Geschwindigkeit und Entfernung in Meilen anstatt Kilometer</string>
-	<string name="use_eng_title">English</string>
-	<string name="use_eng_description">Use English language instead of Android system language</string>
 	<string name="enable_alarms_title">Alarme aktivieren</string>
 	<string name="enable_alarms_description">Das Telefon darf vibrieren</string>
 	<string name="disable_phone_vibrate_title">Telefonvibration deaktivieren</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -135,8 +135,6 @@
 	<string name="max_speed_dial_description">Η μέγιστη ταχύτητα που εμφανίζεται στον εξωτερικό επιλογέα</string>
 	<string name="use_mph_title">Ταχύτητα και απόσταση σε μίλια</string>
 	<string name="use_mph_description">Δείξτε την ταχύτητα και την απόσταση σε μίλια και όχι σε χιλιόμετρα</string>
-	<string name="use_eng_title">English</string>
-	<string name="use_eng_description">Use English language instead of Android system language</string>
 	<string name="enable_alarms_title">Ενεργοποίηση συναγερμών</string>
 	<string name="enable_alarms_description">Επιτρέψτε στο κινητό να δονείται</string>
 	<string name="disable_phone_vibrate_title">Απενεργοποίηση δόνησης κινητού</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -135,8 +135,6 @@
 	<string name="max_speed_dial_description">Velocidad máxima mostrada en el gráfico</string>
 	<string name="use_mph_title">Distancia en millas</string>
 	<string name="use_mph_description">Ver velocidad en millas en vez de kilómetros</string>
-	<string name="use_eng_title">English</string>
-	<string name="use_eng_description">Use English language instead of Android system language</string>
 	<string name="enable_alarms_title">Activar alarmas</string>
 	<string name="enable_alarms_description">Haz que el teléfono vibre</string>
 	<string name="disable_phone_vibrate_title">Desactiva la vibración del teléfono.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -135,8 +135,6 @@
 	<string name="max_speed_dial_description">Vitesse max affiché sur le graphique</string>
 	<string name="use_mph_title">Vitesse et distance en miles</string>
 	<string name="use_mph_description">Affiche la vitesse et la distance en miles plutôt qu\'en kilomètres</string>
-	<string name="use_eng_title">English</string>
-	<string name="use_eng_description">Use English language instead of Android system language</string>
 	<string name="enable_alarms_title">Activation des alarmes</string>
 	<string name="enable_alarms_description">Faire vibrer le téléphone</string>
 	<string name="disable_phone_vibrate_title">Désactiver la vibration du téléphone</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -135,8 +135,6 @@
 	<string name="max_speed_dial_description">Velocità massima visualizzata nel quadrante esterno</string>
 	<string name="use_mph_title">Velocità e distanza in miglia</string>
 	<string name="use_mph_description">Visualizza velocità e distanza in miglia invece che in chilometri</string>
-	<string name="use_eng_title">English</string>
-	<string name="use_eng_description">Use English language instead of Android system language</string>
 	<string name="enable_alarms_title">Allarmi attivati</string>
 	<string name="enable_alarms_description">Fai vibrare lo smartphone come avvertimento</string>
 	<string name="disable_phone_vibrate_title">Disabilita la vibrazione smartphone</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -135,8 +135,6 @@
 	<string name="max_speed_dial_description">Maksymalna prędkość wyświetlana na prędkościomierzu</string>
 	<string name="use_mph_title">Prędkość i dystans w milach</string>
 	<string name="use_mph_description">Pokazuj prędkość i dystans w milach zamiast w kilometrach</string>
-	<string name="use_eng_title">English</string>
-	<string name="use_eng_description">Use English language instead of Android system language</string>
 	<string name="enable_alarms_title">Włącz alarmy</string>
 	<string name="enable_alarms_description">Włącz wibrację telefonu jako ostrzeżenie</string>
 	<string name="disable_phone_vibrate_title">Wyłącz wibrację telefonu</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -135,8 +135,6 @@
 	<string name="max_speed_dial_description">Maksymalna prędkość wyświetlana na prędkościomierzu</string>
 	<string name="use_mph_title">Prędkość i dystans w milach</string>
 	<string name="use_mph_description">Pokazuj prędkość i dystans w milach zamiast w kilometrach</string>
-	<string name="use_eng_title">English</string>
-	<string name="use_eng_description">Use English language instead of Android system language</string>
 	<string name="enable_alarms_title">Włącz alarmy</string>
 	<string name="enable_alarms_description">Włącz wibrację telefonu jako ostrzeżenie</string>
 	<string name="disable_phone_vibrate_title">Wyłącz wibrację telefonu</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -135,8 +135,6 @@
 	<string name="max_speed_dial_description">Velocidade máxima mostrada no indicador externo</string>
 	<string name="use_mph_title">Velocidade e distância em milhas</string>
 	<string name="use_mph_description">Mostrar velocidade e distância em milhas, em vez de quilômetros</string>
-	<string name="use_eng_title">English</string>
-	<string name="use_eng_description">Use English language instead of Android system language</string>
 	<string name="enable_alarms_title">Ativar alarmes</string>
 	<string name="enable_alarms_description">Permitir ao celular vibrar</string>
 	<string name="disable_phone_vibrate_title">Desativar vibração do celular</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -192,7 +192,6 @@
     <string name="cell_voltage_tiltback_description">Напряжение на 1 ячейку, при котором колесо поднимает педали</string>
     <string name="use_eng_alert_description">Пожалуйста перезапустите устройство для смены языка</string>
     <string name="use_eng_alert_title">Необходим перезапуск</string>
-    <string name="use_eng_title">English</string>
     <string name="use_pip_mode_description">Переходить в режим картинка-в-картинке вместо сворачивания</string>
     <string name="use_pip_mode_title">Картинка-в-Картинке</string>
     <string name="voltage_sag">Просадка напряжения</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -256,8 +256,8 @@
     <string name="view_blocks_description">Show info blocks below speedometer</string>
     <string name="use_eng_alert_title">Restart required</string>
     <string name="use_eng_alert_description">Please restart the application to apply the language change</string>
-    <string name="use_eng_title">English</string>
-    <string name="use_eng_description">Use English language instead of Android system language</string>
+    <string name="use_eng_title" translatable="false">English</string>
+    <string name="use_eng_description" translatable="false">Use English language instead of Android system language</string>
     <string name="use_better_percents_title">Improved percents</string>
     <string name="use_better_percents_description">Use better formula for battery percents calculation instead of wheel vendor formula</string>
     <string name="fixed_percents_title">Fixed percents</string>.


### PR DESCRIPTION
- text with the clock is now always in one line
- optimize translations