### PR TITLE
V11 parser fix

### DIFF
--- a/app/src/main/java/com/cooper/wheellog/BluetoothLeService.java
+++ b/app/src/main/java/com/cooper/wheellog/BluetoothLeService.java
@@ -56,7 +56,7 @@ public class BluetoothLeService extends Service {
     PowerManager.WakeLock wl;
 
     FileUtil fileUtilRawData;
-    SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss.SSS", Locale.US);
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy_MM_dd_HH_mm_ss", Locale.US);
 
     private final BroadcastReceiver messageReceiver = new BroadcastReceiver() {
         @Override
@@ -291,7 +291,7 @@ public class BluetoothLeService extends Service {
                 fileUtilRawData = new FileUtil(getApplicationContext());
             }
             if (fileUtilRawData.isNull()) {
-                String fileNameForRawData = "RAW_" + sdf.format(System.currentTimeMillis()) + ".csv";
+                String fileNameForRawData = "RAW_" + sdf.format(new Date()) + ".csv";
                 fileUtilRawData.prepareFile(fileNameForRawData, WheelData.getInstance().getMac());
             }
             fileUtilRawData.writeLine(String.format(Locale.US, "%s,%s",

--- a/app/src/main/java/com/cooper/wheellog/utils/InmotionAdapterV2.java
+++ b/app/src/main/java/com/cooper/wheellog/utils/InmotionAdapterV2.java
@@ -434,45 +434,49 @@ public class InmotionAdapterV2 extends BaseAdapter {
         }
 
         boolean addChar(int c) {
+            if ((c != (byte)0xA5) || oldc == (byte)0xA5){
 
-            switch (state) {
+                switch (state) {
 
-                case collecting:
+                    case collecting:
 
-                    buffer.write(c);
-                    if (buffer.size() == len+5) {
-                        state = UnpackerState.done;
-                        updateStep = 0;
-                        oldc = 0;
-                        Timber.i("Len %d", len);
-                        Timber.i("Step reset");
-                        return true;
-                    }
-                    break;
+                        buffer.write(c);
+                        if (buffer.size() == len + 5) {
+                            state = UnpackerState.done;
+                            updateStep = 0;
+                            oldc = 0;
+                            Timber.i("Len %d", len);
+                            Timber.i("Step reset");
+                            return true;
+                        }
+                        break;
 
-                case lensearch:
-                    buffer.write(c);
-                    len = c & 0xff;
-                    state = UnpackerState.collecting;
-                    oldc = c;
-                    break;
+                    case lensearch:
+                        buffer.write(c);
+                        len = c & 0xff;
+                        state = UnpackerState.collecting;
+                        oldc = c;
+                        break;
 
-                case flagsearch:
-                    buffer.write(c);
-                    flags = c & 0xff;
-                    state = UnpackerState.lensearch;
-                    oldc = c;
-                    break;
+                    case flagsearch:
+                        buffer.write(c);
+                        flags = c & 0xff;
+                        state = UnpackerState.lensearch;
+                        oldc = c;
+                        break;
 
-                default:
-                    if (c == (byte) 0xAA && oldc == (byte) 0xAA) {
-                        buffer = new ByteArrayOutputStream();
-                        buffer.write(0xAA);
-                        buffer.write(0xAA);
-                        state = UnpackerState.flagsearch;
-                    }
-                    oldc = c;
+                    default:
+                        if (c == (byte) 0xAA && oldc == (byte) 0xAA) {
+                            buffer = new ByteArrayOutputStream();
+                            buffer.write(0xAA);
+                            buffer.write(0xAA);
+                            state = UnpackerState.flagsearch;
+                        }
+                        oldc = c;
+                }
 
+            } else {
+                oldc = c;
             }
             return false;
         }

--- a/app/src/main/java/com/cooper/wheellog/utils/InmotionAdapterV2.java
+++ b/app/src/main/java/com/cooper/wheellog/utils/InmotionAdapterV2.java
@@ -434,7 +434,7 @@ public class InmotionAdapterV2 extends BaseAdapter {
         }
 
         boolean addChar(int c) {
-            if ((c != (byte)0xA5) || oldc == (byte)0xA5){
+            if (c != (byte)0xA5 || oldc == (byte)0xA5){
 
                 switch (state) {
 
@@ -514,6 +514,5 @@ public class InmotionAdapterV2 extends BaseAdapter {
     }
 
 }
-
 
 

--- a/app/src/test/java/com/cooper/wheellog/utils/InmotionAdapterV2Test.kt
+++ b/app/src/test/java/com/cooper/wheellog/utils/InmotionAdapterV2Test.kt
@@ -83,4 +83,57 @@ class InmotionAdapterV2Test {
     }
 
 
+    @Test
+    fun `decode with v11 escape data`() {
+        // Arrange.
+        val byteArray1 = "aaaa1431843020a5a50068025207870080009400882c5fc4b000d7001000f4ff2b037c1564190000d9d9492b00000000000000000000a5a5".hexToByteArray() // wheel type
+        // Act.
+        val result1 = adapter.decode(byteArray1)
+        // Assert.
+        assertThat(result1).isTrue()
+        assertThat(data.speedDouble).isEqualTo(6.16)
+        assertThat(data.temperature).isEqualTo(20)
+        assertThat(data.temperature2).isEqualTo(39)
+        assertThat(data.imuTemp).isEqualTo(41)
+        assertThat(data.cpuTemp).isEqualTo(41)
+        assertThat(data.motorPower).isEqualTo(128.0)
+        assertThat(data.currentLimit).isEqualTo(65.00)
+        assertThat(data.speedLimit).isEqualTo(55.00)
+        assertThat(data.torque).isEqualTo(18.74)
+        assertThat(data.voltageDouble).isEqualTo(82.40)
+        assertThat(data.currentDouble).isEqualTo(1.65)
+        assertThat(data.wheelDistanceDouble).isEqualTo(1.48)
+        assertThat(data.batteryLevel).isEqualTo(95)
+        assertThat(data.powerDouble).isEqualTo(135.0)
+        assertThat(data.angle).isEqualTo(0.16)
+        assertThat(data.roll).isEqualTo(8.11)
+    }
+
+    @Test
+    fun `decode with v11 escape data2`() {
+        // Arrange.
+        val byteArray1 = "aaaa143184a5aa1e8100640b1301650059001504a0234cc0b000ce00180000007c007c1564190000d1d3492b00000000000000000000a5a5".hexToByteArray() // wheel type
+        // Act.
+        val result1 = adapter.decode(byteArray1)
+        // Assert.
+        assertThat(result1).isTrue()
+        assertThat(data.speedDouble).isEqualTo(29.16)
+        assertThat(data.temperature).isEqualTo(16)
+        assertThat(data.temperature2).isEqualTo(30)
+        assertThat(data.imuTemp).isEqualTo(35)
+        assertThat(data.cpuTemp).isEqualTo(33)
+        assertThat(data.motorPower).isEqualTo(89.0)
+        assertThat(data.currentLimit).isEqualTo(65.00)
+        assertThat(data.speedLimit).isEqualTo(55.00)
+        assertThat(data.torque).isEqualTo(2.75)
+        assertThat(data.voltageDouble).isEqualTo(78.50)
+        assertThat(data.currentDouble).isEqualTo(1.29)
+        assertThat(data.wheelDistanceDouble).isEqualTo(10.45)
+        assertThat(data.batteryLevel).isEqualTo(76)
+        assertThat(data.powerDouble).isEqualTo(101.0)
+        assertThat(data.angle).isEqualTo(0.24)
+        assertThat(data.roll).isEqualTo(1.24)
+    }
+
+
 }


### PR DESCRIPTION
Как выяснилось, инмо до сих пор использует A5 как escape character для нового протокола, хотя в новом протоколе это и не нужно, т.к. он базируется на длине указанной в заголовке, а не на старт-стопных байтах как это было ранее.
Этим байтом закрываются A5 и AA. Хотя капелька логики в этом есть, АА- это старт пакета.
Самое интересное, что такое событие как появление AA или A5 в данных случается достаточно часто, но в 99.5% случаев такой пакет откидывается т.к. контрольная сумма не сходится. Из-за появления лишнего байта данные сдвигаются, от этого происходит глюк, и CRC обычно становится равной 0x00 в пакете, и естественно она не сходится с реальной CRC.. во всех случаях, кроме случая когда CRC исходного пакета равняется A5. В этом случае при добавлении в данные байта A5 - рассчетная CRC обнуляется и она сходится с 0x00 байтом который попадает в местоположение CRC пакета. 
Т.к. CRC всего один байт - чисто статистически такое событие случается только в 1/256 случаев появления байта A5 - в часовом треке таких случаев у меня оказалось всего два.

Ну и привел название RAW лога в соответствии с названием обычного лога, так гораздо проще найти пару.