### PR TITLE
added sync to creating instance and write BT

### DIFF
--- a/app/src/main/java/com/cooper/wheellog/BluetoothLeService.java
+++ b/app/src/main/java/com/cooper/wheellog/BluetoothLeService.java
@@ -391,7 +391,7 @@ public class BluetoothLeService extends Service {
         Timber.i("Set characteristic %b", success);
     }
 
-    public boolean writeBluetoothGattCharacteristic(byte[] cmd) {
+    public synchronized boolean writeBluetoothGattCharacteristic(byte[] cmd) {
         if (this.mBluetoothGatt == null || cmd == null) {
             return false;
         }

--- a/app/src/main/java/com/cooper/wheellog/WheelData.java
+++ b/app/src/main/java/com/cooper/wheellog/WheelData.java
@@ -1045,9 +1045,10 @@ public class WheelData {
         StringBuilder stringBuilder = new StringBuilder(data.length);
         for (byte aData : data)
             stringBuilder.append(String.format(Locale.US, "%02X", aData));
-        Timber.i("Received: " + stringBuilder.toString());
-//        FileUtil.writeLine("bluetoothOutput.txt", stringBuilder.toString());
-        Timber.i("Decode, proto: %s", protoVer);
+        Timber.i("Received: %s", stringBuilder);
+        if (protoVer != "") {
+            Timber.i("Decode, proto: %s", protoVer);
+        }
         boolean new_data = getAdapter().setContext(mContext).decode(data);
 
         if (!new_data)

--- a/app/src/main/java/com/cooper/wheellog/utils/FileUtil.java
+++ b/app/src/main/java/com/cooper/wheellog/utils/FileUtil.java
@@ -75,6 +75,7 @@ public class FileUtil {
     }
 
     public boolean prepareFile(String fileName, String folder) {
+        Timber.e("Prepare File %s started...", fileName);
         this.fileName = fileName;
         uri = null;
         file = null;

--- a/app/src/main/java/com/cooper/wheellog/utils/FileUtil.java
+++ b/app/src/main/java/com/cooper/wheellog/utils/FileUtil.java
@@ -75,7 +75,6 @@ public class FileUtil {
     }
 
     public boolean prepareFile(String fileName, String folder) {
-        Timber.e("Prepare File %s started...", fileName);
         this.fileName = fileName;
         uri = null;
         file = null;

--- a/app/src/main/java/com/cooper/wheellog/utils/InMotionAdapter.java
+++ b/app/src/main/java/com/cooper/wheellog/utils/InMotionAdapter.java
@@ -1,5 +1,7 @@
 package com.cooper.wheellog.utils;
 
+import android.content.Intent;
+
 import com.cooper.wheellog.R;
 import com.cooper.wheellog.WheelData;
 import com.cooper.wheellog.WheelLog;
@@ -283,7 +285,6 @@ public class InMotionAdapter extends BaseAdapter {
 
     private void setModel(Model value){
         model = value;
-        int a = 0;
     }
 
     public void startKeepAliveTimer(String password) {
@@ -295,31 +296,38 @@ public class InMotionAdapter extends BaseAdapter {
                         if (WheelData.getInstance().bluetoothCmd(InMotionAdapter.CANMessage.getPassword(password).writeBuffer())) {
                             Timber.i("Sent password message");
                             passwordSent++;
-                        } else updateStep = 35;
-
+                        } else {
+                            updateStep = 1;
+                        }
                     } else if (model == UNKNOWN | needSlowData) {
                         if (WheelData.getInstance().bluetoothCmd(InMotionAdapter.CANMessage.getSlowData().writeBuffer())) {
                             Timber.i("Sent infos message");
-                        } else updateStep = 35;
-
+                        } else {
+                            updateStep = 1;
+                        }
                     } else if (settingCommandReady) {
                         if (WheelData.getInstance().bluetoothCmd(settingCommand)) {
                             needSlowData = true;
                             settingCommandReady = false;
                             Timber.i("Sent command message");
-                        } else updateStep = 35; // after +1 and %10 = 0
+                        } else {
+                            updateStep = 1; // after -1 = 0
+                        }
                     } else {
+                        // 40 steps * 25 period = 1 sec
                         if (!WheelData.getInstance().bluetoothCmd(CANMessage.standardMessage().writeBuffer())) {
                             Timber.i("Unable to send keep-alive message");
-                            updateStep = 35;
+                            updateStep = 1;
                         } else {
                             Timber.i("Sent keep-alive message");
                         }
                     }
-
                 }
-                updateStep += 1;
-                updateStep %= 10;
+                // from 40 to 0
+                updateStep--;
+                if (updateStep < 0) {
+                    updateStep = 40;
+                }
                 Timber.i("Step: %d", updateStep);
             }
         };
@@ -1247,7 +1255,7 @@ public class InMotionAdapter extends BaseAdapter {
                 buffer.write(c);
                 if (c == (byte) 0x55 && oldc == (byte) 0x55) {
                     state = UnpackerState.done;
-                    updateStep = 0;
+                    updateStep = 1;
                     oldc = 0;
                     Timber.i("Step reset");
                     return true;
@@ -1277,16 +1285,17 @@ public class InMotionAdapter extends BaseAdapter {
         return 20;
     }
 
-    public static InMotionAdapter getInstance() {
+    public static synchronized InMotionAdapter getInstance() {
         if (INSTANCE == null) {
             Timber.i("New instance");
             INSTANCE = new InMotionAdapter();
+        } else {
+            Timber.i("Get instance");
         }
-        Timber.i("Get instance");
         return INSTANCE;
     }
 
-    public static void newInstance() {
+    public static synchronized void newInstance() {
         if (INSTANCE != null && INSTANCE.keepAliveTimer != null) {
             INSTANCE.keepAliveTimer.cancel();
             INSTANCE.keepAliveTimer = null;
@@ -1295,7 +1304,7 @@ public class InMotionAdapter extends BaseAdapter {
         INSTANCE = new InMotionAdapter();
     }
 
-    public static void stopTimer() {
+    public static synchronized void stopTimer() {
         if (INSTANCE != null && INSTANCE.keepAliveTimer != null) {
             INSTANCE.keepAliveTimer.cancel();
             INSTANCE.keepAliveTimer = null;

--- a/app/src/main/java/com/cooper/wheellog/utils/InmotionAdapterV2.java
+++ b/app/src/main/java/com/cooper/wheellog/utils/InmotionAdapterV2.java
@@ -944,7 +944,7 @@ public class InmotionAdapterV2 extends BaseAdapter {
         return 20;
     }
 
-    public static void newInstance() {
+    public static synchronized void newInstance() {
         if (INSTANCE != null && INSTANCE.keepAliveTimer != null) {
             INSTANCE.keepAliveTimer.cancel();
             INSTANCE.keepAliveTimer = null;
@@ -953,8 +953,7 @@ public class InmotionAdapterV2 extends BaseAdapter {
         INSTANCE = new InmotionAdapterV2();
     }
 
-
-    public static void stopTimer() {
+    public static synchronized void stopTimer() {
         if (INSTANCE != null && INSTANCE.keepAliveTimer != null) {
             INSTANCE.keepAliveTimer.cancel();
             INSTANCE.keepAliveTimer = null;
@@ -962,7 +961,6 @@ public class InmotionAdapterV2 extends BaseAdapter {
         Timber.i("Kill instance, stop timer");
         INSTANCE = null;
     }
-
 }
 
 

--- a/app/src/main/java/com/cooper/wheellog/utils/NinebotAdapter.java
+++ b/app/src/main/java/com/cooper/wheellog/utils/NinebotAdapter.java
@@ -675,7 +675,7 @@ public class NinebotAdapter extends BaseAdapter {
         return INSTANCE;
     }
 
-    public static void newInstance() {
+    public static synchronized void newInstance() {
         if (INSTANCE != null && INSTANCE.keepAliveTimer != null) {
             INSTANCE.keepAliveTimer.cancel();
             INSTANCE.keepAliveTimer = null;
@@ -685,7 +685,7 @@ public class NinebotAdapter extends BaseAdapter {
         INSTANCE = new NinebotAdapter();
     }
 
-    public static void stopTimer() {
+    public static synchronized void stopTimer() {
         if (INSTANCE != null && INSTANCE.keepAliveTimer != null) {
             INSTANCE.keepAliveTimer.cancel();
             INSTANCE.keepAliveTimer = null;

--- a/app/src/main/java/com/cooper/wheellog/utils/NinebotZAdapter.java
+++ b/app/src/main/java/com/cooper/wheellog/utils/NinebotZAdapter.java
@@ -1215,7 +1215,7 @@ public class NinebotZAdapter extends BaseAdapter {
         return INSTANCE;
     }
 
-    public static void newInstance() {
+    public static synchronized void newInstance() {
         if (INSTANCE != null && INSTANCE.keepAliveTimer != null) {
             INSTANCE.keepAliveTimer.cancel();
             INSTANCE.keepAliveTimer = null;
@@ -1224,7 +1224,7 @@ public class NinebotZAdapter extends BaseAdapter {
         INSTANCE = new NinebotZAdapter();
     }
 
-    public static void stopTimer() {
+    public static synchronized void stopTimer() {
         if (INSTANCE != null && INSTANCE.keepAliveTimer != null) {
             INSTANCE.keepAliveTimer.cancel();
             INSTANCE.keepAliveTimer = null;


### PR DESCRIPTION
Запросы создания адаптера и декодирования будут синхронны. Это предотвратит одноврменное выполнение методов, если вызов был из разных потоков/коллбеков. Кто первый вызвал - тот выполняется, остальные вызовы ждут пока предыдущий полностью не выполнится.
Надо потестить.