### PR TITLE
fixes verification inmotion packet when it ends A5 byte

### DIFF
--- a/app/src/main/java/com/cooper/wheellog/utils/InMotionAdapter.java
+++ b/app/src/main/java/com/cooper/wheellog/utils/InMotionAdapter.java
@@ -1237,7 +1237,7 @@ public class InMotionAdapter extends BaseAdapter {
 
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         int oldc = 0;
-        int old2c = 0;
+        int oldestc = 0;
         UnpackerState state = UnpackerState.unknown;
 
         byte[] getBuffer() {
@@ -1247,7 +1247,7 @@ public class InMotionAdapter extends BaseAdapter {
         boolean addChar(int c) {
             if (state == UnpackerState.collecting) {
                 buffer.write(c);
-                if (c == (byte) 0x55 && oldc == (byte) 0x55 && old2c != (byte) 0xA5 && old2c != (byte) 0xAA) {
+                if (c == (byte) 0x55 && oldc == (byte) 0x55 && oldestc != (byte) 0xA5) {
                     state = UnpackerState.done;
                     updateStep = 0;
                     oldc = 0;
@@ -1255,23 +1255,16 @@ public class InMotionAdapter extends BaseAdapter {
                     return true;
                 }
             } else {
-                if (c == (byte) 0xAA && oldc == (byte) 0xAA) {
+                if (c == (byte) 0xAA && oldc == (byte) 0xAA && oldestc != (byte) 0xA5) {
                     buffer = new ByteArrayOutputStream();
                     buffer.write(0xAA);
                     buffer.write(0xAA);
                     state = UnpackerState.collecting;
                 }
             }
-            old2c = oldc;
+            oldestc = oldc;
             oldc = c;
             return false;
-        }
-
-        void reset() {
-            buffer = new ByteArrayOutputStream();
-            oldc = 0;
-            state = UnpackerState.unknown;
-
         }
     }
 

--- a/app/src/main/java/com/cooper/wheellog/utils/InMotionAdapter.java
+++ b/app/src/main/java/com/cooper/wheellog/utils/InMotionAdapter.java
@@ -1247,7 +1247,7 @@ public class InMotionAdapter extends BaseAdapter {
         boolean addChar(int c) {
             if (state == UnpackerState.collecting) {
                 buffer.write(c);
-                if (c == (byte) 0x55 && oldc == (byte) 0x55 && old2c != (byte) 0xA5) {
+                if (c == (byte) 0x55 && oldc == (byte) 0x55 && old2c != (byte) 0xA5 && old2c != (byte) 0xAA) {
                     state = UnpackerState.done;
                     updateStep = 0;
                     oldc = 0;

--- a/app/src/main/java/com/cooper/wheellog/utils/InMotionAdapter.java
+++ b/app/src/main/java/com/cooper/wheellog/utils/InMotionAdapter.java
@@ -810,13 +810,14 @@ public class InMotionAdapter extends BaseAdapter {
                 return null;  // Header and tail not correct
             }
             Timber.i("Before escape %s", StringUtil.toHexString(buffer));
-            byte[] dataBuffer = Arrays.copyOfRange(buffer, 2, buffer.length - 3);
+            int len = buffer.length - 3;
+            byte[] dataBuffer = Arrays.copyOfRange(buffer, 2, len);
 
             dataBuffer = CANMessage.unescape(dataBuffer);
             Timber.i("After escape %s", StringUtil.toHexString(dataBuffer));
             byte check = CANMessage.computeCheck(dataBuffer);
 
-            byte bufferCheck = buffer[buffer.length - 3];
+            byte bufferCheck = buffer[len];
             if (check == bufferCheck) {
                 Timber.i("Check OK");
             } else {
@@ -1236,6 +1237,7 @@ public class InMotionAdapter extends BaseAdapter {
 
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         int oldc = 0;
+        int old2c = 0;
         UnpackerState state = UnpackerState.unknown;
 
         byte[] getBuffer() {
@@ -1245,7 +1247,7 @@ public class InMotionAdapter extends BaseAdapter {
         boolean addChar(int c) {
             if (state == UnpackerState.collecting) {
                 buffer.write(c);
-                if (c == (byte) 0x55 && oldc == (byte) 0x55) {
+                if (c == (byte) 0x55 && oldc == (byte) 0x55 && old2c != (byte) 0xA5) {
                     state = UnpackerState.done;
                     updateStep = 0;
                     oldc = 0;
@@ -1260,6 +1262,7 @@ public class InMotionAdapter extends BaseAdapter {
                     state = UnpackerState.collecting;
                 }
             }
+            old2c = oldc;
             oldc = c;
             return false;
         }

--- a/app/src/test/java/com/cooper/wheellog/utils/InmotionAdapterTest.kt
+++ b/app/src/test/java/com/cooper/wheellog/utils/InmotionAdapterTest.kt
@@ -272,6 +272,30 @@ class InmotionAdapterTest {
     }
 
     @Test
+    fun `decode data with escaped checksum`() {
+        // Arrange.
+        val byteArrays = listOf("aaaa1401a5550f8500000000000000fe02010001".hexToByteArray(),
+                "00da7c5e1a611400000000000000000000000000".hexToByteArray(),
+                "0000001500020200000000070003020000000026".hexToByteArray(),
+                "0301010000000000000a000000000000000200d0".hexToByteArray(),
+                "840000ea0f000000100000000000000000000000".hexToByteArray(),
+                "0000000100000000000000000000000000000000".hexToByteArray(),
+                "00000006000008000000005b0a006f6e01003a00".hexToByteArray(),
+                "0000006c3421000001010a00a5555555".hexToByteArray())
+
+        // Act.
+        var result = false
+        for (bytes in byteArrays) {
+            result = adapter.decode(bytes)
+        }
+
+        // Assert.
+        assertThat(result).isTrue()
+        assertThat(data.model).isEqualTo("Inmotion V8F")
+        assertThat(data.version).isEqualTo("2.2.21")
+    }
+
+    @Test
     fun `light commands`() {
         // Arrange.
         val expectedOn = "aaaa0d01a5550f010000000000000008050000805555".hexToByteArray()


### PR DESCRIPTION
Суть
Байты `AA` и `55` служебные и означают начало и конец пакета (в самом пакете они экранируются байтом `A5`). Но в момент "унпакинга" распаковщик не проверял служебные байты на их экранированность. Это могло приводить к направильной распаковке и ошибке при валидации.