### PR TITLE
fix wearos connection

### DIFF
--- a/app/src/main/java/com/cooper/wheellog/companion/WearOs.kt
+++ b/app/src/main/java/com/cooper/wheellog/companion/WearOs.kt
@@ -27,6 +27,7 @@ class WearOs(var context: Context): MessageClient.OnMessageReceivedListener, Sha
 
     fun sendUpdateData() {
         if (!isConnected) {
+            sendMessage(Constants.wearOsPingMessage)
             return
         }
         val wd = WheelData.getInstance()
@@ -93,7 +94,7 @@ class WearOs(var context: Context): MessageClient.OnMessageReceivedListener, Sha
         addMessageListener()
         sendUpdateData()
         sendPingJob = backgroundScope.launch {
-            sendMessage( Constants.wearOsPingMessage)
+            sendMessage(Constants.wearOsPingMessage)
             delay(500)
             ensureActive()
             // if the wear application did not receive a response from the ping,


### PR DESCRIPTION
При включеннии компаньона через телефон, этот телефон считал что подключения нет и ничего не отправлял.
Работало только если компаньон включать руками заранее.