### PR TITLE
fix setlightmode

### DIFF
--- a/app/src/main/java/com/cooper/wheellog/utils/GotwayAdapter.java
+++ b/app/src/main/java/com/cooper/wheellog/utils/GotwayAdapter.java
@@ -123,7 +123,7 @@ public class GotwayAdapter extends BaseAdapter {
                     if (tiltBackSpeed >= 100) tiltBackSpeed = 0;
                     int alert = buff[12] & 0xFF;
                     int ledMode = buff[13] & 0xFF;
-                    int lightMode = buff[15] & 0xFF;
+                    int lightMode = buff[15] & 0x03;
                     if (lock_Changes == 0) {
                         WheelLog.AppConfig.setPedalsMode(String.valueOf(2 - pedalsMode));
                         WheelLog.AppConfig.setAlarmMode(String.valueOf(speedAlarms)); //CheckMe

--- a/app/src/main/java/com/cooper/wheellog/utils/GotwayAdapter.java
+++ b/app/src/main/java/com/cooper/wheellog/utils/GotwayAdapter.java
@@ -231,6 +231,7 @@ public class GotwayAdapter extends BaseAdapter {
         lock_Changes = 2;
         String command = "";
         switch (lightMode) {
+            default:
             case 0: command = "E"; break;
             case 1: command = "Q"; break;
             case 2: command = "T"; break;


### PR DESCRIPTION
Команда "E" по умолчанию

java.lang.IllegalArgumentException: value byte array is empty
	at com.welie.blessed.BluetoothPeripheral.writeCharacteristic(BluetoothPeripheral.java:1239)
	at com.cooper.wheellog.BluetoothService.writeWheelCharacteristic(BluetoothService.kt:433)
	at com.cooper.wheellog.WheelData.bluetoothCmd(WheelData.java:139)
	at com.cooper.wheellog.utils.GotwayAdapter.sendCommand(GotwayAdapter.java:199)
	at com.cooper.wheellog.utils.GotwayAdapter.sendCommand(GotwayAdapter.java:195)
	at com.cooper.wheellog.utils.GotwayAdapter.sendCommand(GotwayAdapter.java:187)
	at com.cooper.wheellog.utils.GotwayAdapter.setLightMode(GotwayAdapter.java:238)
	at com.cooper.wheellog.preferences.PreferencesFragment.onSharedPreferenceChanged(PreferencesFragment.kt:318)
	at android.app.SharedPreferencesImpl$EditorImpl.notifyListeners(SharedPreferencesImpl.java:612)
	at android.app.SharedPreferencesImpl$EditorImpl.apply(SharedPreferencesImpl.java:494)
	at com.cooper.wheellog.AppConfig.setValue(AppConfig.kt:621)
	at com.cooper.wheellog.AppConfig.setSpecific(AppConfig.kt:612)
	at com.cooper.wheellog.AppConfig.setLightMode(AppConfig.kt:486)
	at com.cooper.wheellog.utils.GotwayAdapter.decode(GotwayAdapter.java:130)
	at com.cooper.wheellog.WheelData.decodeResponse(WheelData.java:992)
	at com.cooper.wheellog.BluetoothService.readData(BluetoothService.kt:220)
	at com.cooper.wheellog.BluetoothService.access$readData(BluetoothService.kt:17)
	at com.cooper.wheellog.BluetoothService$wheelCallback$1.onCharacteristicUpdate(BluetoothService.kt:174)
	at com.welie.blessed.BluetoothPeripheral$1$5.run(BluetoothPeripheral.java:287)