### PR TITLE
fix crash wl release

### DIFF
--- a/app/src/main/java/com/cooper/wheellog/BluetoothService.kt
+++ b/app/src/main/java/com/cooper/wheellog/BluetoothService.kt
@@ -63,7 +63,9 @@ class BluetoothService: Service() {
                     if (noConnectionSound > 0) {
                         stopBeepTimer()
                     }
-                    wl?.release()
+                    if (wl?.isHeld == true) {
+                        wl?.release()
+                    }
                     wl = mgr!!.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, wakeLogTag).apply {
                         acquire(5 * 60 * 1000L /*5 minutes*/)
                     }
@@ -87,10 +89,10 @@ class BluetoothService: Service() {
                     val noConnectionSound = WheelLog.AppConfig.noConnectionSound * 1000
                     if (connectionSound) {
                         playSound(applicationContext, R.raw.sound_disconnect)
-                        if (wl != null) {
-                            wl!!.release()
-                            wl = null
+                        if (wl?.isHeld == true) {
+                            wl?.release()
                         }
+                        wl = null
                         if (noConnectionSound > 0) {
                             startBeepTimer()
                         }
@@ -542,7 +544,9 @@ class BluetoothService: Service() {
     }
 
     private fun stopBeepTimer() {
-        wl?.release()
+        if (wl?.isHeld == true) {
+            wl?.release()
+        }
         wl = null
         beepTimer?.cancel()
         beepTimer = null


### PR DESCRIPTION
java.lang.RuntimeException: WakeLock under-locked WheelLog:WakeLockTag
	at android.os.PowerManager$WakeLock.release(PowerManager.java:1477)
	at android.os.PowerManager$WakeLock.release(PowerManager.java:1447)
	at com.cooper.wheellog.BluetoothService$bluetoothCentralManagerCallback$1.onDisconnectedPeripheral(BluetoothService.kt:84)
	at com.welie.blessed.BluetoothCentralManager$6$5.run(BluetoothCentralManager.java:277)
	at android.os.Handler.handleCallback(Handler.java:836)
	at android.os.Handler.dispatchMessage(Handler.java:103)
	at android.os.Looper.loop(Looper.java:203)
	at android.app.ActivityThread.main(ActivityThread.java:6414)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1113)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:974)