### PR TITLE
fix NoSuchMethodError

### DIFF
--- a/app/src/main/java/com/cooper/wheellog/DialogHelper.kt
+++ b/app/src/main/java/com/cooper/wheellog/DialogHelper.kt
@@ -211,7 +211,7 @@ object DialogHelper {
                     }
                     2 -> TODO("доделать как-то Авто")
                     3 -> {
-                        val temp = templates.getOrDefault(templatesBox.selectedItem, null)
+                        val temp = templates[templatesBox.selectedItem]
                         if (temp != null) {
                             WheelLog.AppConfig.apply {
                                 rotationSpeed = temp.first


### PR DESCRIPTION
На Android 6 и ниже нет метода getOrDefault
```
java.lang.NoSuchMethodError: No interface method getOrDefault(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object; in class Ljava/util/Map; or its super classes (declaration of 'java.util.Map' appears in /system/framework/core-libart.jar)
	at com.cooper.wheellog.DialogHelper.checkPWMIsSetAndShowAlert$lambda$8(DialogHelper.kt:214)
	at com.cooper.wheellog.DialogHelper.$r8$lambda$5hs-lIb308-4Ez7QVPxTPM94WP0(DialogHelper.kt)
	at com.cooper.wheellog.DialogHelper$$ExternalSyntheticLambda6.onClick(D8$$SyntheticClass)
	at androidx.appcompat.app.AlertController$ButtonHandler.handleMessage(AlertController.java:167)
	at android.os.Handler.dispatchMessage(Handler.java:102)
	at android.os.Looper.loop(Looper.java:157)
	at android.app.ActivityThread.main(ActivityThread.java:5603)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:774)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:652)
```