### PR TITLE
fix IllegalStateException at ScrollEventAdapter

### DIFF
--- a/app/src/main/res/layout/main_view_params_list.xml
+++ b/app/src/main/res/layout/main_view_params_list.xml
@@ -6,8 +6,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:animateLayoutChanges="true">
+        android:layout_height="wrap_content">
 
         <androidx.gridlayout.widget.GridLayout
             android:id="@+id/page_two_grid"

--- a/app/src/main/res/layout/main_view_smart_bms.xml
+++ b/app/src/main/res/layout/main_view_smart_bms.xml
@@ -5,8 +5,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:animateLayoutChanges="true">
+        android:layout_height="wrap_content">
 
         <androidx.gridlayout.widget.GridLayout
             xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -14,9 +13,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:columnCount="4"
-            android:animateLayoutChanges="true"
             app:orientation="horizontal">
-
 
         </androidx.gridlayout.widget.GridLayout>
 


### PR DESCRIPTION
```
java.lang.IllegalStateException: Page(s) contain a ViewGroup with a LayoutTransition (or animateLayoutChanges="true"), which interferes with the scrolling animation. Make sure to call getLayoutTransition().setAnimateParentHierarchy(false) on all ViewGroups with a LayoutTransition before an animation is started.
	at androidx.viewpager2.widget.ScrollEventAdapter.updateScrollEventValues(ScrollEventAdapter.java:272)
	at androidx.viewpager2.widget.ScrollEventAdapter.onScrolled(ScrollEventAdapter.java:178)
	at androidx.recyclerview.widget.RecyclerView.dispatchOnScrolled(RecyclerView.java:5173)
	at androidx.recyclerview.widget.RecyclerView$ViewFlinger.run(RecyclerView.java:5338)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1301)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1309)
	at android.view.Choreographer.doCallbacks(Choreographer.java:923)
	at android.view.Choreographer.doFrame(Choreographer.java:847)
	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1283)
	at android.os.Handler.handleCallback(Handler.java:942)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:226)
	at android.os.Looper.loop(Looper.java:313)
	at android.app.ActivityThread.main(ActivityThread.java:8741)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
```

Fix - remove layout animation from ScrollView