### PR TITLE
fix crash in pip

### DIFF
--- a/app/src/main/java/com/cooper/wheellog/MainActivity.kt
+++ b/app/src/main/java/com/cooper/wheellog/MainActivity.kt
@@ -117,16 +117,25 @@ class MainActivity : AppCompatActivity() {
         val toolbar = findViewById<View>(R.id.toolbar)
         val indicator = findViewById<View>(R.id.indicator)
         if (isInPictureInPictureMode) {
-            registerReceiver(mPiPBroadcastReceiver, makeIntentFilter())
-            toolbar.visibility = View.GONE
-            pager.visibility = View.GONE
-            indicator.visibility = View.GONE
-            pipView.setContent {
-                PiPView().SpeedWidget(modifier = Modifier.fillMaxSize(), model = speedModel)
+            try {
+                registerReceiver(mPiPBroadcastReceiver, makeIntentFilter())
+            } catch (_: Exception) {
+                // ignore
+            } finally {
+                toolbar.visibility = View.GONE
+                pager.visibility = View.GONE
+                indicator.visibility = View.GONE
+                pipView.setContent {
+                    PiPView().SpeedWidget(modifier = Modifier.fillMaxSize(), model = speedModel)
+                }
+                pipView.visibility = View.VISIBLE
             }
-            pipView.visibility = View.VISIBLE
         } else {
-            unregisterReceiver(mPiPBroadcastReceiver)
+            try {
+                unregisterReceiver(mPiPBroadcastReceiver)
+            } catch (_: Exception) {
+                // ignore
+            }
             toolbar.visibility = View.VISIBLE
             pager.visibility = View.VISIBLE
             indicator.visibility = View.VISIBLE
@@ -607,7 +616,11 @@ class MainActivity : AppCompatActivity() {
         if (checkNotificationsPermissions(this)) {
             WheelLog.Notifications.update()
         }
-        registerReceiver(mMainViewBroadcastReceiver, makeIntentFilter())
+        try {
+            registerReceiver(mMainViewBroadcastReceiver, makeIntentFilter())
+        } catch (e: Exception) {
+            Timber.e(e)
+        }
         pagerAdapter.updateScreen(true)
     }
 
@@ -619,7 +632,11 @@ class MainActivity : AppCompatActivity() {
     public override fun onPause() {
         super.onPause()
         isPaused = true
-        unregisterReceiver(mMainViewBroadcastReceiver)
+        try {
+            unregisterReceiver(mMainViewBroadcastReceiver)
+        } catch (e: Exception) {
+            Timber.e(e)
+        }
     }
 
     override fun onDestroy() {
@@ -649,7 +666,11 @@ class MainActivity : AppCompatActivity() {
                 Timber.uproot(eventsLoggingTree!!)
                 eventsLoggingTree!!.close()
                 eventsLoggingTree = null
-                unregisterReceiver(mCoreBroadcastReceiver)
+                try {
+                    unregisterReceiver(mCoreBroadcastReceiver)
+                } catch (_: Exception) {
+                    // ignore
+                }
                 // Kill YandexMetrika process.
                 val am = getSystemService(ACTIVITY_SERVICE) as ActivityManager
                 val runningProcesses = am.runningAppProcesses


### PR DESCRIPTION
Из собственного опыта:
- свернуть вилог
- погасить экран
- включить экран
- вылет (но не 100%)

Фикс - проглатывание ошибки.

Из метрики:
```
java.lang.IllegalArgumentException: Receiver not registered: com.cooper.wheellog.MainActivity$mPiPBroadcastReceiver$1@d8d238
	at android.app.LoadedApk.forgetReceiverDispatcher(LoadedApk.java:1568)
	at android.app.ContextImpl.unregisterReceiver(ContextImpl.java:1800)
	at android.content.ContextWrapper.unregisterReceiver(ContextWrapper.java:781)
	at android.content.ContextWrapper.unregisterReceiver(ContextWrapper.java:781)
	at com.cooper.wheellog.MainActivity.onPictureInPictureModeChanged(MainActivity.kt:129)
	at android.app.Activity.dispatchPictureInPictureModeChanged(Activity.java:8592)
	at android.app.ActivityThread.handleWindowingModeChangeIfNeeded(ActivityThread.java:6115)
	at android.app.ActivityThread.performActivityConfigurationChanged(ActivityThread.java:5957)
	at android.app.ActivityThread.performConfigurationChangedForActivity(ActivityThread.java:5934)
	at android.app.ActivityThread.handleActivityConfigurationChanged(ActivityThread.java:6250)
	at android.app.servertransaction.ActivityConfigurationChangeItem.execute(ActivityConfigurationChangeItem.java:55)
	at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45)
	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2259)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loopOnce(Looper.java:210)
	at android.os.Looper.loop(Looper.java:299)
	at android.app.ActivityThread.main(ActivityThread.java:8103)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:556)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1045)
```