### PR TITLE
Added reset maximum values instead reset only top speed and PWM

### DIFF
--- a/app/src/main/java/com/cooper/wheellog/WheelData.java
+++ b/app/src/main/java/com/cooper/wheellog/WheelData.java
@@ -869,9 +869,11 @@ public class WheelData {
         }
     }
 
-    public void resetTopSpeed() {
+    public void resetMaxValues() {
         mTopSpeed = 0;
         mMaxPwm = 0;
+        mMaxCurrent = 0;
+        mMaxPower = 0;
     }
 
     public void resetVoltageSag() {

--- a/app/src/main/java/com/cooper/wheellog/preferences/PreferencesFragment.kt
+++ b/app/src/main/java/com/cooper/wheellog/preferences/PreferencesFragment.kt
@@ -538,11 +538,11 @@ class PreferencesFragment : PreferenceFragmentCompat(), OnSharedPreferenceChange
             }
             SettingsScreen.Trip -> {
                 tb.title = getText(R.string.trip_settings_title)
-                val resetTopButton: Preference? = findPreference(getString(R.string.reset_top_speed))
+                val resetMaxValuesButton: Preference? = findPreference(getString(R.string.reset_max_values))
                 val resetLowestBatteryButton: Preference? = findPreference(getString(R.string.reset_lowest_battery))
                 val resetUserDistanceButton: Preference? = findPreference(getString(R.string.reset_user_distance))
-                resetTopButton?.onPreferenceClickListener = Preference.OnPreferenceClickListener {
-                    WheelData.getInstance().resetTopSpeed()
+                resetMaxValuesButton?.onPreferenceClickListener = Preference.OnPreferenceClickListener {
+                    WheelData.getInstance().resetMaxValues()
                     true
                 }
                 resetLowestBatteryButton?.onPreferenceClickListener = Preference.OnPreferenceClickListener {

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -119,7 +119,8 @@
 	<string name="alarm_settings_title">Алармени настройки</string>
 	<string name="watch_settings_title">Настройки на часовника</string>
 	<string name="wheel_settings_title">Настройки на колелото</string>
-	<string name="reset_top_speed_title">Занулете максималната скорост</string>
+	<string name="reset_max_values_title">Занулете максималните стойности</string>
+	<string name="reset_max_values_description">Нулирайте максималните стойности на скорост, PWM, ток, мощност</string>
 	<string name="reset_user_distance_title">Занулете пробега на потребителя</string>
 	<string name="edit_mac_addr_title">Въведете МАС адрес</string>
 	<string name="about_app_title">За WheelLog</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -119,7 +119,8 @@
 	<string name="alarm_settings_title">Nastavení upozornění</string>
 	<string name="watch_settings_title">Nastavení hodinek</string>
 	<string name="wheel_settings_title">Nastavení jednokolky</string>
-	<string name="reset_top_speed_title">Vynulovat maximální rychlost</string>
+	<string name="reset_max_values_title">Vynulovat maximální hodnoty</string>
+	<string name="reset_max_values_description">Vynulovat maximální hodnoty rychlosti, PWM, proudu, výkonu</string>
 	<string name="reset_user_distance_title">Vynulovat uživatelskou vzdálenost</string>
 	<string name="edit_mac_addr_title">Upravit MAC adresu</string>
 	<string name="about_app_title">O WheelLogu</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -119,7 +119,8 @@
 	<string name="alarm_settings_title">Alarmeinstellungen</string>
 	<string name="watch_settings_title">Uhreinstellungen</string>
 	<string name="wheel_settings_title">Radeinstellungen</string>
-	<string name="reset_top_speed_title">Spitzengeschwindigkeit zurücksetzen</string>
+	<string name="reset_max_values_title">Spitzengeschwindigkeit zurücksetzen</string>
+	<string name="reset_max_values_description">Скинути максимальні значення швидкісти, PWM, силі струма, потужністи</string>
 	<string name="reset_user_distance_title">Benutzerentfernung zurücksetzen</string>
 	<string name="edit_mac_addr_title">MAC adresse ändern</string>
 	<string name="about_app_title">Über WheelLog</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -119,7 +119,8 @@
 	<string name="alarm_settings_title">Ρυθμίσεις συναγερμών</string>
 	<string name="watch_settings_title">Προτιμήσεις ρολογιού</string>
 	<string name="wheel_settings_title">Ρυθμίσεις Ρόδας</string>
-	<string name="reset_top_speed_title">Επαναφορά της μέγιστης ταχύτητας</string>
+	<string name="reset_max_values_title">Επαναφέρετε τις μέγιστες τιμές</string>
+	<string name="reset_max_values_description">Επαναφέρετε τις μέγιστες τιμές ταχύτητας, PWM, ρεύματος, ισχύος</string>
 	<string name="reset_user_distance_title">Επαναφορά της απόστασης χρήστη</string>
 	<string name="edit_mac_addr_title">Επεξεργασία διεύθυνσης MAC</string>
 	<string name="about_app_title">Σχετικά με το WheelLog</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -119,7 +119,8 @@
 	<string name="alarm_settings_title">configuración de alarmas</string>
 	<string name="watch_settings_title">Configuración del relog</string>
 	<string name="wheel_settings_title">Configuración de la rueda</string>
-	<string name="reset_top_speed_title">Restablecer la velocidad máxima.</string>
+	<string name="reset_max_values_title">Restablecer valores máximos.</string>
+	<string name="reset_max_values_description">Restablecer valores máximos de velocidad, PWM, corriente, potencia</string>
 	<string name="reset_user_distance_title">Restablecer la distancia del usuario.</string>
 	<string name="edit_mac_addr_title">Editar de la dirección MAC</string>
 	<string name="about_app_title">Acerca de WheelLog</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -119,7 +119,8 @@
 	<string name="alarm_settings_title">Paramètres alarmes</string>
 	<string name="watch_settings_title">Préferences montre</string>
 	<string name="wheel_settings_title">Paramétrage de la roue</string>
-	<string name="reset_top_speed_title">Réinitialisation vitesse maximum</string>
+	<string name="reset_max_values_title">Réinitialisation les valeurs maximales</string>
+	<string name="reset_max_values_description">Réinitialisation les valeurs maximales de vitesse, PWM, courant, puissance</string>
 	<string name="reset_user_distance_title">Réinitialisation distance utilisateur</string>
 	<string name="edit_mac_addr_title">Edition addresse MAC</string>
 	<string name="about_app_title">A propos de WheelLog</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -119,7 +119,8 @@
 	<string name="alarm_settings_title">Impostazioni allarmi</string>
 	<string name="watch_settings_title">Preferenze orologio</string>
 	<string name="wheel_settings_title">Impostazioni ruota</string>
-	<string name="reset_top_speed_title">Reset velocità massima</string>
+	<string name="reset_max_values_title">Reset valori massimi</string>
+	<string name="reset_max_values_description">Azzera i valori massimi di velocità, PWM, corrente, potenza</string>
 	<string name="reset_user_distance_title">Reset distanza utente</string>
 	<string name="edit_mac_addr_title">Imposta MAC address</string>
 	<string name="about_app_title">Informazioni su WheelLog</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -166,7 +166,8 @@
     <string name="watch_settings_title">"워치 설정"</string>
     <string name="wheel_settings_title">"휠 설정"</string>
     <string name="trip_settings_title">"여행 설정"</string>
-    <string name="reset_top_speed_title"></string>
+    <string name="reset_max_values_title">최대값을 재설정합니다</string>
+    <string name="reset_max_values_description">속도, PWM, 전류, 전력의 최대값을 재설정합니다</string>
     <string name="reset_lowest_battery_title"></string>
     <string name="reset_user_distance_title">"사용자 거리 초기화"</string>
     <string name="edit_mac_addr_title">"MAC 주소 수정"</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -119,7 +119,8 @@
 	<string name="alarm_settings_title">Ustawienia alarmów</string>
 	<string name="watch_settings_title">Ustawienia zegarka</string>
 	<string name="wheel_settings_title">Ustawienia monocykla</string>
-	<string name="reset_top_speed_title">Zeruj prędkość maksymalną</string>
+	<string name="reset_max_values_title">Zeruj wartości maksymalną</string>
+	<string name="reset_max_values_description">Zresetuj maksymalne wartości prędkości, PWM, prądu, mocy</string>
 	<string name="reset_user_distance_title">Zeruj dystans użytkownika</string>
 	<string name="edit_mac_addr_title">Edytuj adres MAC</string>
 	<string name="about_app_title">O programie</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -119,7 +119,8 @@
 	<string name="alarm_settings_title">Ustawienia alarmów</string>
 	<string name="watch_settings_title">Ustawienia zegarka</string>
 	<string name="wheel_settings_title">Ustawienia monocykla</string>
-	<string name="reset_top_speed_title">Zeruj prędkość maksymalną</string>
+	<string name="reset_max_values_title">Zeruj wartości maksymalną</string>
+	<string name="reset_max_values_description">Zresetuj maksymalne wartości prędkości, PWM, prądu, mocy</string>
 	<string name="reset_user_distance_title">Zeruj dystans użytkownika</string>
 	<string name="edit_mac_addr_title">Edytuj adres MAC</string>
 	<string name="about_app_title">O programie</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -119,7 +119,8 @@
 	<string name="alarm_settings_title">Configurações dos alarmes</string>
 	<string name="watch_settings_title">Preferências do Relógio</string>
 	<string name="wheel_settings_title">Configuração do Monociclo</string>
-	<string name="reset_top_speed_title">Resetar Velocidade Máxima</string>
+	<string name="reset_max_values_title">Resetar valores Máxima</string>
+	<string name="reset_max_values_description">Redefina os valores máximos de velocidade, PWM, corrente, potência</string>
 	<string name="reset_user_distance_title">Resetar Distância do Usuário</string>
 	<string name="edit_mac_addr_title">Editar MAC adress</string>
 	<string name="about_app_title">Sobre WheelLog</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -183,7 +183,8 @@
     <string name="logging_error_no_storage_permission">Нет разрешения на запись файлов. Логи не будут записаны</string>
     <string name="logging_error_storage_unavailable">Внешнее хранилище не доступно, логгирование отменено</string>
     <string name="reset_lowest_battery_title">Сбросить просадку напряжения</string>
-    <string name="reset_top_speed_title">Сбросить максимальную скорость и PWM</string>
+    <string name="reset_max_values_title">Сбросить максимальные значения</string>
+    <string name="reset_max_values_description">Сбросить максимальную скорость, PWM, ток, мощность</string>
     <string name="search_for_wheel">Найти колесо</string>
     <string name="searching">Поиск</string>
     <string name="start_data_service">Логирование запущено</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -171,7 +171,8 @@
     <string name="logging_error_no_storage_permission">Немає дозволу на запис файлів. Логи не будуть записані</string>
     <string name="logging_error_storage_unavailable">Зовнішнє сховище не доступне, логування скасовано</string>
     <string name="reset_lowest_battery_title">Скинути просадку напруги</string>
-    <string name="reset_top_speed_title">Скинути максимальну швидкість</string>
+    <string name="reset_max_values_title">Скинути максимальні значення</string>
+    <string name="reset_max_values_description">Скинути максимальні значення швидкісти, PWM, силі струма, потужністи</string>
     <string name="search_for_wheel">Знайти колесо</string>
     <string name="searching">Пошук</string>
     <string name="start_data_service">Логування заборонено</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -113,7 +113,8 @@
     <string name="alarm_settings_title">报警设置</string>
     <string name="watch_settings_title">手表设置</string>
     <string name="wheel_settings_title">轮子设置</string>
-    <string name="reset_top_speed_title">重置最高速度</string>
+    <string name="reset_max_values_title">重置最高大值</string>
+    <string name="reset_max_values_description">重置速度、PWM、电流、功率的最高大值</string>
     <string name="reset_user_distance_title">重置用户距离</string>
     <string name="edit_mac_addr_title">编辑MAC地址</string>
     <string name="about_app_title">关于WheelLog</string>

--- a/app/src/main/res/values/constants.xml
+++ b/app/src/main/res/values/constants.xml
@@ -142,7 +142,7 @@
     <string name="garmin_connectiq_use_beta" translatable="false">garmin_connectiq_use_beta</string>
 
     // TRIP PREFERENCES
-    <string name="reset_top_speed" translatable="false">reset_top_speed</string>
+    <string name="reset_max_values" translatable="false">reset_max_values</string>
     <string name="reset_user_distance" translatable="false">reset_user_distance</string>
     <string name="reset_lowest_battery" translatable="false">reset_lowest_battery</string>
     <string name="last_mac" translatable="false">last_mac</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -163,7 +163,8 @@
     <string name="watch_settings_title">Watch/Band Preferences</string>
     <string name="wheel_settings_title">Wheel Settings</string>
     <string name="trip_settings_title">Trip Settings</string>
-    <string name="reset_top_speed_title">Reset top speed and PWM</string>
+    <string name="reset_max_values_title">Reset maximum values</string>
+    <string name="reset_max_values_description">Reset maximum values of speed, PWM, current, power</string>
     <string name="reset_lowest_battery_title">Reset battery sag</string>
     <string name="reset_user_distance_title">Reset user distance</string>
     <string name="edit_mac_addr_title">Edit MAC address</string>

--- a/app/src/main/res/xml/preferences_trip.xml
+++ b/app/src/main/res/xml/preferences_trip.xml
@@ -3,9 +3,10 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
 
 	<Preference
-		android:key="@string/reset_top_speed"
 		android:enabled="true"
-		android:title="@string/reset_top_speed_title" />
+		android:key="@string/reset_max_values"
+		android:summary="@string/reset_max_values_description"
+		android:title="@string/reset_max_values_title" />
 
 	<Preference
 		android:enabled="true"


### PR DESCRIPTION
Обсуждение запроса из чата:

> Предлагаю поклянчить в следующей версии функцию сброса пиков (макс мощность, ток, пвм, просадка, скорость...), например двойным тапом через оконце подтверждения

> логичнее в первую добавить также сброс макс. мощности и макс. тока, а текст изменить на "сбросить пиковые значения" или "сбросить максимальные значения".

> угу. И в описание добавить текущие максимальные значения, которые будут сброшены.

> Вообще я имел ввиду не кнопки где-то в дебрях меню, я имел ввиду прям в главном экране тапнул по параметру - он сбросился. Сейчас там в любое место тапай - оно свет включает (кстати, на В11 не включает! :)). Предлагаю оставить свет тапом по спидометру, а тапы по блокам с цифирьками - сбрасывают максимумы (где применимо)

> тогда любое случайное прикосновение в экран будет сбрасывать параметры. Поведение какое то неожиданное и не очень ожидаемое. Фиксация максимальных значений сделана для справки, от этих данных толку примерно ноль, поэтому заморачиваться и устраивать целый круговорот вокруг этого функционала это перебор.