### PR TITLE
Fix onDestroy crash

### DIFF
--- a/app/src/main/java/com/cooper/wheellog/MainActivity.kt
+++ b/app/src/main/java/com/cooper/wheellog/MainActivity.kt
@@ -96,12 +96,20 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
-        override fun onServiceDisconnected(componentName: ComponentName) {
-            if (componentName.className == BluetoothService::class.java.name) {
+        fun disconnect(componentName: ComponentName?) {
+            if (componentName?.className == BluetoothService::class.java.name) {
                 WheelData.getInstance().bluetoothService = null
                 WheelData.getInstance().isConnected = false
                 Timber.e("BluetoothService disconnected")
             }
+        }
+
+        override fun onServiceDisconnected(componentName: ComponentName) {
+            disconnect(componentName)
+        }
+
+        override fun onBindingDied(name: ComponentName?) {
+            disconnect(name)
         }
     }
 
@@ -702,8 +710,12 @@ class MainActivity : AppCompatActivity() {
         stopLoggingService()
         WheelData.getInstance().full_reset()
         if (bluetoothService != null) {
-            unbindService(mBluetoothServiceConnection)
-            WheelData.getInstance().bluetoothService = null
+            try {
+                unbindService(mBluetoothServiceConnection)
+                WheelData.getInstance().bluetoothService = null
+            } catch (_: Exception) {
+                // ignored
+            }
         }
         WheelLog.ThemeManager.changeAppIcon(this@MainActivity)
         object : CountDownTimer((2 * 60 * 1000 /* 2 min */).toLong(), 1000) {


### PR DESCRIPTION
```
java.lang.RuntimeException: Unable to destroy activity {com.cooper.wheellog/com.cooper.wheellog.MainActivity}: java.lang.IllegalArgumentException: Service not registered: com.cooper.wheellog.MainActivity$mBluetoothServiceConnection$1@f61e863
	at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:5878)
	at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:5908)
	at android.app.servertransaction.DestroyActivityItem.execute(DestroyActivityItem.java:44)
	at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:190)
	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:105)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2613)
	at android.os.Handler.dispatchMessage(Handler.java:110)
	at android.os.Looper.loop(Looper.java:219)
	at android.app.ActivityThread.main(ActivityThread.java:8676)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:513)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1109)
Caused by: java.lang.IllegalArgumentException: Service not registered: com.cooper.wheellog.MainActivity$mBluetoothServiceConnection$1@f61e863
	at android.app.LoadedApk.forgetServiceDispatcher(LoadedApk.java:1987)
	at android.app.ContextImpl.unbindService(ContextImpl.java:1904)
	at android.content.ContextWrapper.unbindService(ContextWrapper.java:741)
	at android.content.ContextWrapper.unbindService(ContextWrapper.java:741)
	at com.cooper.wheellog.MainActivity.onDestroy(MainActivity.kt:705)
	at android.app.Activity.performDestroy(Activity.java:8478)
	at android.app.Instrumentation.callActivityOnDestroy(Instrumentation.java:1355)
	at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:5863)
	... 11 more
```