### PR TITLE
Fix crash getting adv data

### DIFF
--- a/app/src/main/java/com/cooper/wheellog/AppConfig.kt
+++ b/app/src/main/java/com/cooper/wheellog/AppConfig.kt
@@ -597,10 +597,6 @@ class AppConfig(var context: Context) {
             setValue("wheel_password_$specificPrefix", password)
         }
 
-    var advDataForWheel: String
-        get() = getValue("wheel_adv_data_$specificPrefix", "")
-        set(value) = setValue("wheel_adv_data_$specificPrefix", value)
-
     var userDistance: Long
         get() = getValue("user_distance_$specificPrefix", 0L)
         set(value) = setValue("user_distance_$specificPrefix", value)

--- a/app/src/main/java/com/cooper/wheellog/BluetoothService.kt
+++ b/app/src/main/java/com/cooper/wheellog/BluetoothService.kt
@@ -445,7 +445,7 @@ class BluetoothService: Service() {
                     return wheelConnection!!.writeCharacteristic(characteristic, cmd, WriteType.WITHOUT_RESPONSE)
                 }
                 WHEEL_TYPE.NINEBOT -> {
-                    if (WheelData.getInstance().protoVer.compareTo("") == 0) {
+                    if (NinebotAdapter.getProtoFromAdvData().compareTo("") == 0) {
                         val characteristic = getServiceCharacteristic(
                             Constants.NINEBOT_SERVICE_UUID,
                             Constants.NINEBOT_WRITE_CHARACTER_UUID

--- a/app/src/main/java/com/cooper/wheellog/MainActivity.kt
+++ b/app/src/main/java/com/cooper/wheellog/MainActivity.kt
@@ -1007,9 +1007,7 @@ class MainActivity : AppCompatActivity() {
     private val scanLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
         if (result.resultCode == RESULT_OK && bluetoothService != null) {
             mDeviceAddress = result.data?.getStringExtra("MAC") ?: ""
-            Timber.i("Device selected = %s", mDeviceAddress)
             val mDeviceName = result.data?.getStringExtra("NAME")
-            Timber.i("Device selected = %s", mDeviceName)
             bluetoothService!!.wheelAddress = mDeviceAddress
             WheelData.getInstance().full_reset()
             WheelData.getInstance().btName = mDeviceName

--- a/app/src/main/java/com/cooper/wheellog/MainPageAdapter.kt
+++ b/app/src/main/java/com/cooper/wheellog/MainPageAdapter.kt
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.cooper.wheellog.utils.Constants.WHEEL_TYPE
 import com.cooper.wheellog.utils.FileUtil
 import com.cooper.wheellog.utils.MathsUtil
+import com.cooper.wheellog.utils.NinebotAdapter
 import com.cooper.wheellog.utils.SomeUtil.getColorEx
 import com.cooper.wheellog.utils.StringUtil.inArray
 import com.cooper.wheellog.utils.StringUtil.toTempString
@@ -771,7 +772,7 @@ class MainPageAdapter(private var pages: MutableList<Int>, val activity: MainAct
                 }
             }
             WHEEL_TYPE.NINEBOT_Z -> {
-                if (WheelData.getInstance().protoVer == "") { //hide page for S2
+                if (NinebotAdapter.getProtoFromAdvData() == "") { //hide page for S2
                     addPage(R.layout.main_view_smart_bms, 2)
                     setupFieldForSmartBmsPage(R.string.bmsSn)
                     setupFieldForSmartBmsPage(R.string.bmsFw)

--- a/app/src/main/java/com/cooper/wheellog/ScanActivity.kt
+++ b/app/src/main/java/com/cooper/wheellog/ScanActivity.kt
@@ -26,6 +26,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import com.cooper.wheellog.databinding.ActivityScanBinding
+import com.cooper.wheellog.utils.NinebotAdapter
 import com.cooper.wheellog.utils.PermissionsUtil
 import com.cooper.wheellog.utils.StringUtil
 import com.cooper.wheellog.utils.StringUtil.toHexStringRaw
@@ -184,27 +185,38 @@ class ScanActivity: AppCompatActivity() {
         intent.putExtra("NAME", deviceName)
         WheelLog.AppConfig.lastMac = deviceAddress
         WheelLog.AppConfig.advDataForWheel = advData
+
+        // advData used only for ninebot adapter.
+        NinebotAdapter.setProtoFromAdvData(advData)
+
         setResult(RESULT_OK, intent)
         // Set password for inmotion
         WheelLog.AppConfig.passwordForWheel = ""
         close()
     }
 
+    private infix fun Byte.eq(i: Int): Boolean = this == i.toByte()
+
     private fun findManufacturerData(scanRecord: ByteArray): String {
         var index = 0
         var result = ""
         while (index < scanRecord.size) {
-            val length = scanRecord[index++].toInt()
+            val length = scanRecord[index++]
             // Done once we run out of records
-            if (length == 0) break
-            val type = scanRecord[index].toInt()
+            val toIndex = index + length
+            if (length eq 0 || toIndex > scanRecord.size) {
+                break
+            }
+            val type = scanRecord[index]
             // Done if our record isn't a valid type
-            if (type == 0) break
-            val data = scanRecord.copyOfRange(index + 1, index + length)
+            if (type eq 0) {
+                break
+            }
+            val data = scanRecord.copyOfRange(index + 1, toIndex)
 
             // Advance
-            index += length
-            if (type == -1) {
+            index = toIndex
+            if (type eq -1) {
                 result = toHexStringRaw(data)
             }
         }

--- a/app/src/main/java/com/cooper/wheellog/ScanActivity.kt
+++ b/app/src/main/java/com/cooper/wheellog/ScanActivity.kt
@@ -186,6 +186,7 @@ class ScanActivity: AppCompatActivity() {
         WheelLog.AppConfig.lastMac = deviceAddress
 
         // advData used only for ninebot adapter.
+        WheelData.getInstance().bleAdvData = advData
         NinebotAdapter.setProtoFromAdvData(advData)
 
         setResult(RESULT_OK, intent)

--- a/app/src/main/java/com/cooper/wheellog/ScanActivity.kt
+++ b/app/src/main/java/com/cooper/wheellog/ScanActivity.kt
@@ -187,7 +187,7 @@ class ScanActivity: AppCompatActivity() {
 
         // advData used only for ninebot adapter.
         WheelData.getInstance().bleAdvData = advData
-        NinebotAdapter.setProtoFromAdvData(advData)
+        NinebotAdapter.setAdvData(advData)
 
         setResult(RESULT_OK, intent)
         // Set password for inmotion

--- a/app/src/main/java/com/cooper/wheellog/ScanActivity.kt
+++ b/app/src/main/java/com/cooper/wheellog/ScanActivity.kt
@@ -187,7 +187,6 @@ class ScanActivity: AppCompatActivity() {
 
         // advData used only for ninebot adapter.
         WheelData.getInstance().bleAdvData = advData
-        NinebotAdapter.setAdvData(advData)
 
         setResult(RESULT_OK, intent)
         // Set password for inmotion

--- a/app/src/main/java/com/cooper/wheellog/ScanActivity.kt
+++ b/app/src/main/java/com/cooper/wheellog/ScanActivity.kt
@@ -184,7 +184,6 @@ class ScanActivity: AppCompatActivity() {
         intent.putExtra("MAC", deviceAddress)
         intent.putExtra("NAME", deviceName)
         WheelLog.AppConfig.lastMac = deviceAddress
-        WheelLog.AppConfig.advDataForWheel = advData
 
         // advData used only for ninebot adapter.
         NinebotAdapter.setProtoFromAdvData(advData)

--- a/app/src/main/java/com/cooper/wheellog/WheelData.java
+++ b/app/src/main/java/com/cooper/wheellog/WheelData.java
@@ -102,6 +102,8 @@ public class WheelData {
     private long timestamp_last;
     private long mLastLifeData = -1;
 
+    public String bleAdvData = "";
+
     public BaseAdapter getAdapter() {
         switch (mWheelType) {
             case GOTWAY_VIRTUAL:
@@ -1152,6 +1154,7 @@ public class WheelData {
         rideStartTime = 0;
         mStartTotalDistance = 0;
         mWheelIsReady = false;
+        bleAdvData = "";
     }
 
     boolean detectWheel(String deviceAddress, Context mContext, int servicesResId) {
@@ -1287,6 +1290,7 @@ public class WheelData {
 
             } else if (WHEEL_TYPE.NINEBOT_Z.toString().equalsIgnoreCase(adapterName)) {
                 Timber.i("Trying to start Ninebot Z");
+                NinebotAdapter.setProtoFromAdvData(bleAdvData);
                 var advProto = NinebotAdapter.getProtoFromAdvData();
                 if (advProto.compareTo("") == 0) {
                     Timber.i("really Z");
@@ -1343,6 +1347,7 @@ public class WheelData {
                     mBluetoothService.writeWheelDescriptor(descriptor, BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE);
                     Timber.i("write notify");
                 }
+                NinebotAdapter.setProtoFromAdvData(bleAdvData);
                 NinebotAdapter.getInstance().startKeepAliveTimer(NinebotAdapter.getProtoFromAdvData());
                 Timber.i("starting ninebot adapter");
                 return true;

--- a/app/src/main/java/com/cooper/wheellog/WheelData.java
+++ b/app/src/main/java/com/cooper/wheellog/WheelData.java
@@ -1290,7 +1290,7 @@ public class WheelData {
 
             } else if (WHEEL_TYPE.NINEBOT_Z.toString().equalsIgnoreCase(adapterName)) {
                 Timber.i("Trying to start Ninebot Z");
-                NinebotAdapter.setProtoFromAdvData(bleAdvData);
+                NinebotAdapter.setAdvData(bleAdvData);
                 var advProto = NinebotAdapter.getProtoFromAdvData();
                 if (advProto.compareTo("") == 0) {
                     Timber.i("really Z");
@@ -1347,7 +1347,7 @@ public class WheelData {
                     mBluetoothService.writeWheelDescriptor(descriptor, BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE);
                     Timber.i("write notify");
                 }
-                NinebotAdapter.setProtoFromAdvData(bleAdvData);
+                NinebotAdapter.setAdvData(bleAdvData);
                 NinebotAdapter.getInstance().startKeepAliveTimer(NinebotAdapter.getProtoFromAdvData());
                 Timber.i("starting ninebot adapter");
                 return true;

--- a/app/src/main/java/com/cooper/wheellog/WheelData.java
+++ b/app/src/main/java/com/cooper/wheellog/WheelData.java
@@ -98,8 +98,6 @@ public class WheelData {
     private long mLowSpeedMusicTime = 0;
 
     private boolean mBmsView = false;
-    private String protoVer = "";
-
     private long timestamp_raw;
     private long timestamp_last;
     private long mLastLifeData = -1;
@@ -282,10 +280,6 @@ public class WheelData {
 
     public String getBtName() {
         return mBtName;
-    }
-
-    public String getProtoVer() {
-        return protoVer;
     }
 
     public void updateLight(boolean enabledLight) {
@@ -999,9 +993,6 @@ public class WheelData {
         for (byte aData : data)
             stringBuilder.append(String.format(Locale.US, "%02X", aData));
         Timber.i("Received: %s", stringBuilder);
-        if (protoVer != "") {
-            Timber.i("Decode, proto: %s", protoVer);
-        }
         boolean new_data = getAdapter().decode(data);
 
         if (!new_data)
@@ -1160,21 +1151,12 @@ public class WheelData {
         mBtName = "";
         rideStartTime = 0;
         mStartTotalDistance = 0;
-        protoVer = "";
         mWheelIsReady = false;
     }
 
     boolean detectWheel(String deviceAddress, Context mContext, int servicesResId) {
         WheelLog.AppConfig.setLastMac(deviceAddress);
-        String advData = WheelLog.AppConfig.getAdvDataForWheel();
         String adapterName = "";
-        protoVer = "";
-        if (StringUtil.inArray(advData, new String[]{"4e421300000000ec", "4e421302000000ea",})) {
-            protoVer = "S2";
-        } else if (StringUtil.inArray(advData, new String[]{"4e421400000000eb", "4e422000000000df", "4e422200000000dd", "4e4230cf"}) || (advData.startsWith("5600"))) {
-            protoVer = "Mini";
-        }
-        Timber.i("ProtoVer %s, adv: %s", protoVer, advData );
         boolean detected_wheel = false;
         String text = StringUtil.getRawTextResource(mContext, servicesResId);
         if (mBluetoothService == null) {
@@ -1305,7 +1287,8 @@ public class WheelData {
 
             } else if (WHEEL_TYPE.NINEBOT_Z.toString().equalsIgnoreCase(adapterName)) {
                 Timber.i("Trying to start Ninebot Z");
-                if (protoVer.compareTo("") == 0) {
+                var advProto = NinebotAdapter.getProtoFromAdvData();
+                if (advProto.compareTo("") == 0) {
                     Timber.i("really Z");
                     setWheelType(WHEEL_TYPE.NINEBOT_Z);
                 } else {
@@ -1330,9 +1313,9 @@ public class WheelData {
                     mBluetoothService.writeWheelDescriptor(descriptor, BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE);
                 }
                 Timber.i("write notify");
-                if (protoVer.compareTo("S2") == 0 || protoVer.compareTo("Mini") == 0) {
-                    NinebotAdapter.getInstance().startKeepAliveTimer(protoVer);
-                    Timber.i("starting ninebot adapter, proto: %s", protoVer);
+                if (advProto.compareTo("S2") == 0 || advProto.compareTo("Mini") == 0) {
+                    NinebotAdapter.getInstance().startKeepAliveTimer(advProto);
+                    Timber.i("starting ninebot adapter, proto: %s", advProto);
                 } else {
                     NinebotZAdapter.getInstance().startKeepAliveTimer();
                     Timber.i("starting ninebot Z adapter");
@@ -1360,7 +1343,7 @@ public class WheelData {
                     mBluetoothService.writeWheelDescriptor(descriptor, BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE);
                     Timber.i("write notify");
                 }
-                NinebotAdapter.getInstance().startKeepAliveTimer(protoVer);
+                NinebotAdapter.getInstance().startKeepAliveTimer(NinebotAdapter.getProtoFromAdvData());
                 Timber.i("starting ninebot adapter");
                 return true;
             }

--- a/app/src/main/java/com/cooper/wheellog/utils/NinebotAdapter.java
+++ b/app/src/main/java/com/cooper/wheellog/utils/NinebotAdapter.java
@@ -717,7 +717,7 @@ public class NinebotAdapter extends BaseAdapter {
         return _protoFromAdvData;
     }
 
-    public static void setProtoFromAdvData(String advData) {
+    public static void setAdvData(String advData) {
         _protoFromAdvData = "";
         if (StringUtil.inArray(advData, new String[]{"4e421300000000ec", "4e421302000000ea",})) {
             _protoFromAdvData = "S2";

--- a/app/src/main/java/com/cooper/wheellog/utils/NinebotAdapter.java
+++ b/app/src/main/java/com/cooper/wheellog/utils/NinebotAdapter.java
@@ -91,7 +91,7 @@ public class NinebotAdapter extends BaseAdapter {
             Timber.i(status.toString());
             if (status instanceof NinebotAdapter.serialNumberStatus) {
                 wd.setSerial(((serialNumberStatus) status).getSerialNumber());
-                wd.setModel("Ninebot " + wd.getProtoVer());
+                wd.setModel("Ninebot " + getProtoFromAdvData());
             } else if (status instanceof NinebotAdapter.versionStatus) {
                 wd.setVersion(((NinebotAdapter.versionStatus) status).getVersion());
             } else {
@@ -709,5 +709,21 @@ public class NinebotAdapter extends BaseAdapter {
         }
         Timber.i("Kill instance, stop timer");
         INSTANCE = null;
+    }
+
+    private static String _protoFromAdvData = "";
+
+    public static String getProtoFromAdvData() {
+        return _protoFromAdvData;
+    }
+
+    public static void setProtoFromAdvData(String advData) {
+        _protoFromAdvData = "";
+        if (StringUtil.inArray(advData, new String[]{"4e421300000000ec", "4e421302000000ea",})) {
+            _protoFromAdvData = "S2";
+        } else if (StringUtil.inArray(advData, new String[]{"4e421400000000eb", "4e422000000000df", "4e422200000000dd", "4e4230cf"}) || (advData.startsWith("5600"))) {
+            _protoFromAdvData = "Mini";
+        }
+        Timber.i("ProtoVer %s, adv: %s", _protoFromAdvData, advData);
     }
 }


### PR DESCRIPTION
protoVer в ninebot + крэш
```
java.lang.IndexOutOfBoundsException: toIndex (90) is greater than size (62).
	at kotlin.collections.ArraysKt__ArraysJVMKt.copyOfRangeToIndexCheck(ArraysJVM.kt:49)
	at kotlin.collections.ArraysKt___ArraysJvmKt.copyOfRange(_ArraysJvm.kt:1843)
	at com.cooper.wheellog.ScanActivity.findManufacturerData(ScanActivity.kt:203)
	at com.cooper.wheellog.ScanActivity.access$findManufacturerData(ScanActivity.kt:39)
	at com.cooper.wheellog.ScanActivity$bluetoothCentralManagerCallback$1.onDiscoveredPeripheral(ScanActivity.kt:118)
	at com.welie.blessed.BluetoothCentralManager$3.run(BluetoothCentralManager.java:148)
	at android.os.Handler.handleCallback(Handler.java:883)
	at android.os.Handler.dispatchMessage(Handler.java:100)
	at android.os.Looper.loop(Looper.java:224)
	at android.app.ActivityThread.main(ActivityThread.java:7590)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:539)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950)
```