### PR TITLE
Notifications builder

### DIFF
--- a/app/src/main/java/com/cooper/wheellog/utils/NotificationBuilder.kt
+++ b/app/src/main/java/com/cooper/wheellog/utils/NotificationBuilder.kt
@@ -1,0 +1,96 @@
+package com.cooper.wheellog.utils
+
+import android.content.Context
+import com.cooper.wheellog.R
+import java.math.RoundingMode
+import java.text.DecimalFormat
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+fun buildNotification(
+    context: Context,
+    config: NotificationContent.() -> Unit
+): CharSequence {
+    val notificationContent = NotificationContent()
+    notificationContent.config()
+    return notificationContent.buildNotification(context)
+}
+
+
+class NotificationContent {
+
+    sealed class WhatToDisplay {
+        data class DistanceKm(val value: Double) : WhatToDisplay()
+        data class TemperatureDegreesOfCelsius(val value: Int) : WhatToDisplay()
+        data class BatteryLevel(val value: Int) : WhatToDisplay()
+        data class SpeedKmPh(val value: Double) : WhatToDisplay()
+    }
+
+    private val itemsDisplayed = mutableListOf<WhatToDisplay>()
+
+    var useMiles: Boolean = false
+    var useFahrenheits: Boolean = false
+    var prefix: String = ""
+    var separator: String = ""
+
+    var distanceKm: Double by writeOnlyProperty { itemsDisplayed.add(WhatToDisplay.DistanceKm(it)) }
+    var temperatureDegreesOfCelsius: Int by writeOnlyProperty {
+        itemsDisplayed.add(WhatToDisplay.TemperatureDegreesOfCelsius(it))
+    }
+    var batteryLevelPct: Int by writeOnlyProperty { itemsDisplayed.add(WhatToDisplay.BatteryLevel(it)) }
+    var speedKmPh: Double by writeOnlyProperty { itemsDisplayed.add(WhatToDisplay.SpeedKmPh(it)) }
+
+    private fun <T> writeOnlyProperty(function: (t: T) -> Boolean): ReadWriteProperty<NotificationContent, T> {
+        return object : ReadWriteProperty<NotificationContent, T> {
+            override fun getValue(thisRef: NotificationContent, property: KProperty<*>): T {
+                throw UnsupportedOperationException("Property ${property.name} is write-only")
+            }
+
+            override fun setValue(thisRef: NotificationContent, property: KProperty<*>, value: T) {
+                function(value)
+            }
+        }
+    }
+
+    fun buildNotification(context: Context): CharSequence {
+        return prefix + itemsDisplayed.joinToString(separator) {
+            when (it) {
+                is WhatToDisplay.BatteryLevel -> "${it.value}%"
+                is WhatToDisplay.DistanceKm -> if (useMiles) {
+                    "${
+                        MathsUtil.kmToMiles(it.value).formatDecimal()
+                    } ${context.getString(R.string.miles)}"
+                } else {
+                    "${it.value.formatDecimal()} ${context.getString(R.string.km)}"
+                }
+
+                is WhatToDisplay.TemperatureDegreesOfCelsius ->
+                    if (useFahrenheits) {
+                        "${
+                            MathsUtil.celsiusToFahrenheit(it.value.toDouble()).formatDecimal(0)
+                        }${context.getString(R.string.degrees_of_fahrenheit)}"
+                    } else {
+                        "${it.value}${context.getString(R.string.degrees_of_celsius)}"
+                    }
+
+                is WhatToDisplay.SpeedKmPh -> if (useMiles) {
+                    "${
+                        MathsUtil.kmToMiles(it.value).formatDecimal()
+                    } ${context.getString(R.string.mph)}"
+                } else {
+                    "${it.value.formatDecimal()} ${context.getString(R.string.kmh)}"
+                }
+            }
+        }
+
+    }
+
+    private fun Double.formatDecimal(maxFractionDigits: Int = 1): String =
+        DecimalFormat().apply {
+            isGroupingUsed = false
+            minimumFractionDigits = 0
+            maximumFractionDigits = maxFractionDigits
+            isDecimalSeparatorAlwaysShown = false
+            roundingMode = RoundingMode.HALF_UP
+        }.format(this)
+}

--- a/app/src/main/java/com/cooper/wheellog/utils/NotificationUtil.kt
+++ b/app/src/main/java/com/cooper/wheellog/utils/NotificationUtil.kt
@@ -85,11 +85,28 @@ class NotificationUtil(private val context: Context) {
             if (WheelLog.AppConfig.mibandMode == MiBandEnum.Alarm) {
                 notificationView.setTextViewText(R.id.text_message, context.getString(R.string.alarmmiband))
             } else {
-                val template = when (WheelLog.AppConfig.appTheme) {
-                    R.style.AJDMTheme -> R.string.notification_text_ajdm_theme
-                    else -> R.string.notification_text
-                }
-                notificationView.setTextViewText(R.id.text_message, context.getString(template, speed, batteryLevel, temperature, distance))
+                notificationView.setTextViewText(R.id.text_message,
+                    buildNotification(context) {
+                        // notification content
+                        speedKmPh = speed
+                        batteryLevelPct = batteryLevel
+                        temperatureDegreesOfCelsius = temperature
+                        distanceKm = distance
+                        // formatting options
+                        when (WheelLog.AppConfig.appTheme) {
+                            R.style.AJDMTheme -> {
+                                prefix = ""
+                                separator = " | "
+                            }
+                            else -> {
+                                prefix =  "•"
+                                separator =  " • "
+                            }
+                        }
+                        useFahrenheits = WheelLog.AppConfig.useFahrenheit
+                        useMiles = WheelLog.AppConfig.useMph
+                    }
+                )
                 notificationView.setTextViewText(R.id.text_title, "$title - $titleRide")
             }
         } else {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,8 @@
     <string name="sec">sec</string>
     <string name="min">min</string>
     <string name="miles">mi</string>
+    <string name="degrees_of_fahrenheit">℉</string>
+    <string name="degrees_of_celsius">℃</string>
 
     // Garmin ConnectIQ dialogs
     <string name="garmin_connectiq_missing_app_message">The WheelLog App used with this application is not installed on your ConnectIQ device. Please install the widget and try again.</string>
@@ -88,8 +90,6 @@
     <string name="version">Version</string>
     <string name="serial_number">Serial Number</string>
     <string name="time_charge_title">Charge Time</string>
-    <string name="notification_text">• %1$.1f km/h • %2$d%% • %3$d°C • %4$.1f km •</string>
-    <string name="notification_text_ajdm_theme">%1$.1f km/h | %2$d%% | %3$d°C | %4$.1f km</string>
     <string name="icon_watch">Watch Icon</string>
     <string name="icon_logging">Logging Icon</string>
     <string name="icon_connection">Connection Icon</string>

--- a/app/src/test/java/com/cooper/wheellog/utils/NotificationContentTest.kt
+++ b/app/src/test/java/com/cooper/wheellog/utils/NotificationContentTest.kt
@@ -1,0 +1,55 @@
+package com.cooper.wheellog.utils
+
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@Config(sdk = [30, 33])
+@RunWith(RobolectricTestRunner::class)
+class NotificationContentTest {
+
+    @Test
+    fun `prefix only notification`() {
+        assertEquals("*", buildNotification(RuntimeEnvironment.getApplication()) {
+            prefix = "*"
+        })
+    }
+
+    @Test
+    fun `prefix, separator ignored, battery level, celsius`() {
+        assertEquals("* 37℃", buildNotification(RuntimeEnvironment.getApplication()) {
+            prefix = "* "
+            separator = " | "
+            temperatureDegreesOfCelsius = 37
+        })
+    }
+
+    @Test
+    fun `prefix, separator, battery level, distance, celsius, kilometer`() {
+        assertEquals("* 11.1 km | 37℃ | 80%", buildNotification(RuntimeEnvironment.getApplication()) {
+            prefix = "* "
+            separator = " | "
+            distanceKm = 11.1
+            temperatureDegreesOfCelsius = 37
+            batteryLevelPct = 80
+        })
+    }
+
+    @Test
+    fun `prefix, separator, battery level, distance, fahrenheit, miles`() {
+        assertEquals("* 6.9 mi | 99℉ | 80%", buildNotification(RuntimeEnvironment.getApplication()) {
+            prefix = "* "
+            separator = " | "
+            useMiles = true
+            useFahrenheits = true
+
+            distanceKm = 11.1
+            temperatureDegreesOfCelsius = 37
+            batteryLevelPct = 80
+
+        })
+    }
+}


### PR DESCRIPTION
I created builder for notifications. It follows idea of original notification string but it is locale aware. 

I also found unused strings 

```xml
    <string name="notification_text_alarm_not">Alarm data: %1$.0f k/h | %2$.1f A | %3$.2f V | %4$d %% | %5$d °C</string>
    <string name="notification_text_not">%1$.0f km/h | %2$d %% | %3$.0f W | %4$d°C | %5$.3f km</string>
```

that can be also built by that new builder (it would require slight modification to add Watts, Amperes and Volts)

I also added some unit tests to test whether it works well. 