### PR TITLE
Allow turning off logging when the wheel is disconnected

### DIFF
--- a/app/src/main/java/com/cooper/wheellog/MainActivity.kt
+++ b/app/src/main/java/com/cooper/wheellog/MainActivity.kt
@@ -549,8 +549,13 @@ class MainActivity : AppCompatActivity() {
                     miSearch!!.isEnabled = true
                     miSearch!!.icon!!.alpha = 255
                 }
-                miLogging!!.isEnabled = false
-                miLogging!!.icon!!.alpha = 64
+                if (LoggingService.isInstanceCreated()) {
+                    miLogging!!.isEnabled = true
+                    miLogging!!.icon!!.alpha = 255
+                } else {
+                    miLogging!!.isEnabled = false
+                    miLogging!!.icon!!.alpha = 64
+                }
             }
             else -> {}
         }


### PR DESCRIPTION
Currently, you have to reconnect your wheel in order to turn off logging. This makes it so you can always turn logging off, even when the wheel is no longer connected.