### PR TITLE
Improvements in case of negative speed and current

### DIFF
--- a/app/src/main/java/com/cooper/wheellog/utils/GotwayAdapter.java
+++ b/app/src/main/java/com/cooper/wheellog/utils/GotwayAdapter.java
@@ -112,15 +112,14 @@ public class GotwayAdapter extends BaseAdapter {
                         appConfig.setTrick(buff[16]);
                     }
                     int hwPwm = MathsUtil.signedShortFromBytesBE(buff, 14) * 10;
+                    speed = Math.abs(speed);
                     if (gotwayNegative == 0) {
-                        speed = Math.abs(speed);
                         phaseCurrent = Math.abs(phaseCurrent);
                         hwPwm = Math.abs(hwPwm);
                     } else {
                         phaseCurrent = phaseCurrent * gotwayNegative;
                         if (!bIsAlexovikFW)
                         {
-                            speed = speed * gotwayNegative;
                             hwPwm = hwPwm * gotwayNegative;
                         }
                     }

--- a/app/src/main/java/com/cooper/wheellog/utils/VeteranAdapter.java
+++ b/app/src/main/java/com/cooper/wheellog/utils/VeteranAdapter.java
@@ -179,11 +179,11 @@ public class VeteranAdapter extends BaseAdapter {
                     }
                 } else battery = 1; // for new wheels, set 1% by default
 
+                speed = Math.abs(speed);
+
                 if (veteranNegative == 0) {
-                    speed = Math.abs(speed);
                     phaseCurrent = Math.abs(phaseCurrent);
                 } else {
-                    speed = speed * veteranNegative;
                     phaseCurrent = phaseCurrent * veteranNegative;
                 }
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -166,8 +166,8 @@
     <string name="integral_d_current_factor_decsription">Интегральный коэффициент тока D двигателя.</string>
     <string name="battery_voltage_title">Напряжение батареи</string>
     <string name="battery_voltage_description">67В/84В/100В</string>
-    <string name="gotway_negative_title">Отрицательный ток и скорость</string>
-    <string name="gotway_negative_description">Когда вы едете прямо, если скорость и ток отрицательные - попробуйте изменить настройку на противоположную или выберите абсолютное значение</string>
+    <string name="gotway_negative_title">Отрицательный ток</string>
+    <string name="gotway_negative_description">Когда вы едете прямо, если ток отрицательные - попробуйте изменить настройку на противоположную или выберите абсолютное значение</string>
     <string name="absolute">Абсолютный (всегда положительный)</string>
     <string name="reverse">Обратный</string>
     <string name="straight">Прямой</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -261,8 +261,8 @@
     <string name="auto_upload_log_ec_description">Автоматичне завантаження логу. Потрібно увімкнути GPS.</string>
     <string name="ks18l_scaler_title">Корегування одометру 18L</string>
     <string name="ks18l_scaler_description">Якщо Ваш 18L неправильно відображає дистанцію - виберіть даний пункт</string>
-    <string name="gotway_negative_title">Дзеркальний режим сили струму та напруги</string>
-    <string name="gotway_negative_description">Якщо заначення напруги та сили струму відображається навапаки - спробуйте даний параметр</string>
+    <string name="gotway_negative_title">Дзеркальний режим напруги</string>
+    <string name="gotway_negative_description">Якщо заначення напруги відображається навапаки - спробуйте даний параметр</string>
     <string name="absolute">Абсолютне значення</string>
     <string name="reverse">Реверс</string>
     <string name="straight">Нормальний режим</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -359,8 +359,8 @@
     <string name="integral_d_current_factor_decsription">Integral current factor D of the motor.</string>
     <string name="battery_voltage_title">Battery voltage</string>
     <string name="battery_voltage_description">67V/84V/100V/116V/134V/168V</string>
-    <string name="gotway_negative_title">Negative current and speed mode</string>
-    <string name="gotway_negative_description">When you riding straight if speed and currents negative - try change to opposite setting, or choose absolute</string>
+    <string name="gotway_negative_title">Negative current mode</string>
+    <string name="gotway_negative_description">When you riding straight if currents negative - try change to opposite setting, or choose absolute</string>
     <string name="hw_pwm_title">Use hardware PWM instead of software</string>
     <string name="hw_pwm_description">Modern versions of Veteran firmware support PWM transmission in protocol, switch to activate</string>
     <string name="absolute">Absolute (only positive)</string>


### PR DESCRIPTION
When used with Patton-S, the speed value is negative, and the current is correct. To make it work at least somehow, you need to enable the current and speed reverser. In this case, the speed is normal, and the current is reversed. If you enable absolute values, then the current will never be negative (which happens when braking) and the consumption will be calculated incorrectly. But negative speed does not make sense. Therefore, I suggest using the setting to reverse only the current value, and always make the speed absolute.