### PR TITLE
Enable Patton S headlight on connect

### DIFF
--- a/app/src/main/java/com/cooper/wheellog/WheelData.java
+++ b/app/src/main/java/com/cooper/wheellog/WheelData.java
@@ -996,6 +996,10 @@ public class WheelData {
     }
 
     void setConnected(boolean connected) {
+        if (mConnectionState != connected) {
+            mWheelIsReady = false;
+        }
+
         mConnectionState = connected;
         Timber.i("State %b", connected);
     }
@@ -1131,6 +1135,15 @@ public class WheelData {
 
         if (!mWheelIsReady && getAdapter().isReady()) {
             mWheelIsReady = true;
+
+            if (
+                    mWheelType == WHEEL_TYPE.VETERAN
+                            && VeteranAdapter.getInstance().getVer() == 7
+                            && appConfig.getLightEnabled()
+            ) {
+                updateLight(true);
+            }
+
             var isReadyIntent = new Intent(Constants.ACTION_WHEEL_IS_READY);
             mContext.sendBroadcast(isReadyIntent);
         }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -179,8 +179,8 @@
     <string name="off_level_2_alarm">Только 80% PWM</string>
     <string name="on_level_alarm">30 + 35 (45) км/ч + 80% PWM</string>
     <string name="metre">м</string>
-    <string name="on_headlight_title">Включение фонаря</string>
-    <string name="on_headlight_description">Включает передний фонарь для освещения дороги.</string>
+    <string name="on_headlight_title">Включать фару при подключении</string>
+    <string name="on_headlight_description">Фара будет включаться автоматически после подключения к колесу.</string>
     <string name="autolight_description">Автоматическое включение света</string>
     <string name="leds_settings_title">Включает светодиодную подсветку</string>
     <string name="leds_settings_description">Включает бугущие огни светодиодов по бокам.</string>


### PR DESCRIPTION
## Что изменено

Добавлено автоматическое включение фары при подключении к Veteran Patton S.
Если настройка включена, после подключения и готовности колеса приложение отправляет команду включения фары. Если настройка выключена — фара автоматически не включается.

## Исправленный нюанс

При тестировании обнаружилось, что автозапуск фары срабатывал только при первом подключении после запуска приложения.
Если приложение оставалось открытым, а колесо выключалось и включалось заново, фара не включалась автоматически. Причина была в том, что флаг `mWheelIsReady` оставался `true` после предыдущего подключения, поэтому блок готовности колеса больше не выполнялся.
Теперь `mWheelIsReady` сбрасывается при изменении состояния подключения, поэтому при повторном подключении колесо снова проходит состояние ready, и автозапуск фары срабатывает повторно.

## Поведение

- Работает только для Veteran Patton S.
- Не затрагивает другие модели.
- Если переключатель включён — фара включается при подключении и переподключении.
- Если переключатель выключен — фара автоматически не включается.
- Ручное управление переключателем сохранено.

## Проверено

Проверено на Veteran Patton S:

- первое подключение после запуска приложения;
- выключение и повторное включение колеса без перезапуска приложения;
- включённый переключатель включает фару автоматически;
- выключенный переключатель не включает фару автоматически.